### PR TITLE
Fix whyrun on Chef 12.x / Ruby 2.x

### DIFF
--- a/providers/account.rb
+++ b/providers/account.rb
@@ -136,10 +136,11 @@ end
 def home_dir_resource(exec_action)
   # avoid variable scoping issues in resource block
   my_home = @my_home
+  resource_gid = user_gid
   r = directory my_home do
     path        my_home
     owner       new_resource.username
-    group       user_gid
+    group       resource_gid
     mode        node['user']['home_dir_mode']
     recursive   true
     action      :nothing
@@ -151,10 +152,11 @@ end
 def home_ssh_dir_resource(exec_action)
   # avoid variable scoping issues in resource block
   my_home = @my_home
+  resource_gid = user_gid
   r = directory "#{my_home}/.ssh" do
     path        "#{my_home}/.ssh"
     owner       new_resource.username
-    group       user_gid
+    group       resource_gid
     mode        '0700'
     recursive   true
     action      :nothing
@@ -170,11 +172,12 @@ def authorized_keys_resource(exec_action)
   unless ssh_keys.empty?
     home_ssh_dir_resource(exec_action)
 
+    resource_gid = user_gid
     r = template "#{@my_home}/.ssh/authorized_keys" do
       cookbook    'user'
       source      'authorized_keys.erb'
       owner       new_resource.username
-      group       user_gid
+      group       resource_gid
       mode        '0600'
       variables   :user     => new_resource.username,
         :ssh_keys => ssh_keys,


### PR DESCRIPTION
As per comments in https://github.com/opscode-cookbooks/openssl/issues/10

Scoping issue under Ruby 2.x.
